### PR TITLE
.aws/configがあれば参照する

### DIFF
--- a/import_json.go
+++ b/import_json.go
@@ -70,7 +70,13 @@ func main() {
 		log.Fatalf("failed to load config: %v\n", err)
 	}
 
-	svc := ssm.New(session.New(), &aws.Config{
+	sess, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		log.Fatalf("failed to get session: %v\n", err)
+	}
+	svc := ssm.New(sess, &aws.Config{
 		Region: aws.String(config.Region),
 	})
 


### PR DESCRIPTION
AssumeRoleや `aws sso login` する場合、**~/.aws/config** に設定を書いて **~/.aws/credentials** には何も書かないことがある。デフォルトでは **~/.aws/credentials** しか読まないので *SharedConfigEnable* オプションを有効にした。

- [session#Shared Config Fields](https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#hdr-Shared_Config_Fields)

このオプションは参照するファイルが増えるので**credentials**と競合するものがあれば既存の環境が壊れることも想定されるけど、一般的には多くはないと思う。

ついでに、`session.New` は deprecated となっていて、`session.NewSession` を使えとある。
https://github.com/aws/aws-sdk-go/blob/67d3a1d0add4e9bc3806236f02e3f8c4ff331ba6/aws/session/session.go#L81-L84

この差分では`session.NewSessionWithOptions`を使っているが、`session.NewSession` と `session.NewSessionWithOptions` の違いは、単にオプションの渡し方が違うだけで実体は同じ。
https://github.com/aws/aws-sdk-go/blob/67d3a1d0add4e9bc3806236f02e3f8c4ff331ba6/aws/session/session.go#L148-L153