### PR TITLE
Slackにtweetの本文を投稿

### DIFF
--- a/functions/saba_disambiguator/main.go
+++ b/functions/saba_disambiguator/main.go
@@ -194,10 +194,8 @@ func formatTweetIntoSlackPayload(t *twitter.Tweet) slack.Payload {
 						AltText:  t.User.ScreenName,
 					},
 					slack.TextObject{
-						Type: "mrkdwn",
-						// If t.User.Name contains '*', then bolding name will be broken.
-						// I don't know how to fix it, and it may be OK.
-						Text: fmt.Sprintf("*%s* @%s", t.User.Name, t.User.ScreenName),
+						Type: "plain_text",
+						Text: fmt.Sprintf("%s @%s", t.User.Name, t.User.ScreenName),
 					},
 				},
 			},

--- a/functions/saba_disambiguator/slack/objects.go
+++ b/functions/saba_disambiguator/slack/objects.go
@@ -1,0 +1,41 @@
+package slack
+
+// https://api.slack.com/reference/messaging/payload
+type Payload struct {
+	Text        string `json:"text"`
+	Blocks      []any  `json:"blocks,omitempty"`
+	Attachments []any  `json:"attachments,omitempty"`
+	ThreadTs    string `json:"thread_ts,omitempty"`
+	Mrkdwn      bool   `json:"mrkdwn,omitempty"`
+}
+
+// https://api.slack.com/reference/block-kit/blocks#context
+type ContextBlock struct {
+	Type     string `json:"type"`
+	Elements []any  `json:"elements"`
+	BlockID  string `json:"block_id,omitempty"`
+}
+
+// https://api.slack.com/reference/messaging/block-elements#image
+type ImageElement struct {
+	Type     string `json:"type"`
+	ImageURL string `json:"image_url"`
+	AltText  string `json:"alt_text"`
+}
+
+// https://api.slack.com/reference/messaging/composition-objects#text
+type TextObject struct {
+	Type     string `json:"type"`
+	Text     string `json:"text"`
+	Emoji    bool   `json:"emoji,omitempty"`
+	Verbatim bool   `json:"verbatim,omitempty"`
+}
+
+// https://api.slack.com/reference/block-kit/blocks#section
+type SectionBlock struct {
+	Type      string       `json:"type"`
+	Text      TextObject   `json:"text,omitempty"`
+	BlockID   string       `json:"block_id,omitempty"`
+	Fields    []TextObject `json:"fields,omitempty"`
+	Accessory any          `json:"accessory,omitempty"`
+}


### PR DESCRIPTION
以下のように投稿されるはず

<img width="482" alt="Screenshot 2023-04-26 at 17 05 38" src="https://user-images.githubusercontent.com/76464810/234511004-ed0a19fa-62ec-456a-b962-7019deea016d.png">


## やったこと
- [Slackのレイアウトブロック](https://api.slack.com/block-kit/building)をつかってアイコンを表示できるようにした。
- Tweetの本文を取得する
- permalinkも貼り付ける