### PR TITLE
不要なjsonの要素を消した

### DIFF
--- a/functions/saba_disambiguator/main.go
+++ b/functions/saba_disambiguator/main.go
@@ -210,9 +210,8 @@ func formatTweetIntoSlackPayload(t *twitter.Tweet) slack.Payload {
 			slack.SectionBlock{
 				Type: "section",
 				Text: slack.TextObject{
-					Type:  "mrkdwn",
-					Text:  permalink,
-					Emoji: false,
+					Type: "mrkdwn",
+					Text: permalink,
 				},
 			},
 		},


### PR DESCRIPTION
`type: mrkdwn`のときemoji要素は無いので

https://api.slack.com/reference/block-kit/composition-objects#text