### PR TITLE
twitter2 を使うように変更

### DIFF
--- a/lib/example.go
+++ b/lib/example.go
@@ -3,7 +3,7 @@ package sabadisambiguator
 import (
 	"math/rand"
 
-	"github.com/dghubble/go-twitter/twitter"
+	twitter2 "github.com/syou6162/saba_disambiguator/twitter"
 )
 
 type LabelType int
@@ -16,12 +16,12 @@ const (
 type Example struct {
 	Label LabelType `json:"Label"`
 	Fv    FeatureVector
-	Tweet twitter.Tweet
+	Tweet *twitter2.Tweet
 }
 
 type Examples []*Example
 
-func NewExampleWithOptions(tweet twitter.Tweet, label LabelType, opts ExtractOptions) *Example {
+func NewExampleWithOptions(tweet *twitter2.Tweet, label LabelType, opts ExtractOptions) *Example {
 	fv := ExtractFeaturesWithOptions(tweet, opts)
 	return &Example{Label: label, Fv: fv, Tweet: tweet}
 }

--- a/lib/perceptron.go
+++ b/lib/perceptron.go
@@ -40,7 +40,7 @@ func NewPerceptronClassifier(examples Examples) *PerceptronClassifier {
 	for _, e := range dev {
 		predLabel := model.Predict(e.Fv)
 		if predLabel != e.Label {
-			url := fmt.Sprintf("https://twitter.com/%s/status/%s", e.Tweet.User.ScreenName, e.Tweet.IDStr)
+			url := fmt.Sprintf("https://twitter.com/%s/status/%s", e.Tweet.User.UserName, e.Tweet.ID)
 			fmt.Println(fmt.Sprintf("%d\t%d\t%s", e.Label, predLabel, url))
 		}
 	}


### PR DESCRIPTION
## 背景
twitter API v1.0 廃止したので、 twitter API v2 への対応
twitter API v2 のパッケージを実装するのは #249 で行った。この PR では既存の実装の twitter v1 を使っていた部分を twitter v2 を使うように変更した。

## 注意する点
テストがない、試してもないです。