### PR TITLE
スクリーンネームの誤検知が多いので対処したい

### DIFF
--- a/functions/saba_disambiguator/build/config_sample.yml
+++ b/functions/saba_disambiguator/build/config_sample.yml
@@ -1,4 +1,4 @@
-query: "mackerel lang:ja exclude:retweets"
+query: "mackerel lang:ja -is:retweet"
 region: "ap-northeast-1"
 twitter: # Twitterから情報を取得するためのシークレットキーが保存されているAWSパラメータストアの名前を書きます
   parameterStoreNameConsumerKey: "/path/to/ConsumerKey"

--- a/functions/saba_disambiguator/build/config_sample.yml
+++ b/functions/saba_disambiguator/build/config_sample.yml
@@ -13,6 +13,10 @@ bigquery:
   projectId: my-project
   dataset: my_dataset
   table: my_table 
+# 特定アカウントへの返信または引用かどうかを特徴量の計算に利用します
+# スクリーンネームの比較は完全一致です
+#
+# 以前の挙動を維持するため、screenNamesが未設定の場合は 'mackerel' という文字列を含むかどうかで判定します
 screenNames:
   - mackerelio
   - mackerelio_jp

--- a/lib/feature.go
+++ b/lib/feature.go
@@ -141,9 +141,11 @@ func ExtractFeaturesWithOptions(t *twitter2.Tweet, opts ExtractOptions) FeatureV
 	text := t.Text
 
 	fv = append(fv, "BIAS")
-	fv = append(fv, "ScreenName:"+t.User.UserName)
-	fv = append(fv, "inReplyToScreenName:"+inReplyToScreenName(t))
-	fv = append(fv, "screenNameInQuotedStatus:"+screenNameInQuotedStatus(t))
+	if len(opts.ScreenNames) == 0 {
+		fv = append(fv, "ScreenName:"+t.User.UserName)
+		fv = append(fv, "inReplyToScreenName:"+inReplyToScreenName(t))
+		fv = append(fv, "screenNameInQuotedStatus:"+screenNameInQuotedStatus(t))
+	}
 	fv = append(fv, "lang:"+lang(t))
 	fv = append(fv, "containsNameInScreenName:"+strconv.FormatBool(opts.contains(t.User.UserName)))
 	fv = append(fv, "includeNameInUserMentions:"+strconv.FormatBool(opts.includeScreenNameInUserMentions(t)))

--- a/lib/feature.go
+++ b/lib/feature.go
@@ -145,9 +145,9 @@ func ExtractFeaturesWithOptions(t *twitter2.Tweet, opts ExtractOptions) FeatureV
 	fv = append(fv, "inReplyToScreenName:"+inReplyToScreenName(t))
 	fv = append(fv, "screenNameInQuotedStatus:"+screenNameInQuotedStatus(t))
 	fv = append(fv, "lang:"+lang(t))
-	fv = append(fv, "containsMackerelInScreenName:"+strconv.FormatBool(opts.contains(t.User.UserName)))
-	fv = append(fv, "includeMackerelInUserMentions:"+strconv.FormatBool(opts.includeScreenNameInUserMentions(t)))
-	fv = append(fv, "includeMackerelInReplyToScreenName:"+strconv.FormatBool(opts.includeScreenNameInReplyToScreenName(t)))
+	fv = append(fv, "containsNameInScreenName:"+strconv.FormatBool(opts.contains(t.User.UserName)))
+	fv = append(fv, "includeNameInUserMentions:"+strconv.FormatBool(opts.includeScreenNameInUserMentions(t)))
+	fv = append(fv, "includeNameInReplyToScreenName:"+strconv.FormatBool(opts.includeScreenNameInReplyToScreenName(t)))
 
 	fv = append(fv, ExtractNounFeatures(text, "Text")...)
 	fv = append(fv, extractNounFeaturesFromQuotedText(t)...)


### PR DESCRIPTION
### 問題

- `@mackerel__xx` のようなスクリーンネームに反応してしまって誤検知が多い
- スクリーンネームをnegativeとして学習してもいいけれど時間がかかるし、個数も多い

### 対応内容

- スクリーンネームを学習の対象から外した(返信や引用も含む)
- sampleの設定にコメントも追加した

#### 経緯

もともとスクリーンネームの検知は **"mackerel"** 固定だったが #228 で *screenNames* パラメータを使って任意の値に変えられるようになった。 *screenNames* パラメータは「引用や返信に該当のスクリーンネームが含まれているか」を学習に利用するもので、含まれている場合は(重みづけの結果で)検出されやすくはなるだろうが、これ自体が検索結果のフィルタを行うわけではない。あくまで学習材料のひとつ。

ところで、Xは検索するとスクリーンネームに一致したポストも結果に含まれる。以前は `OR @i -@i` のように書けば除けたらしいが今はできない。そのため、検索結果に「スクリーンネームにマッチしたポスト」も含まれる。

検索クエリがスクリーンネームに反応した場合に不要なポストを除きたいが、例えば **mackerel** で検索したとき `@mackerel__xxx` ユーザーがMackerelのことを話している場合もあるので、単純に除外はできない。また、検出するとき最終的なスコアを基準に判断するため「どの部分にマッチしたか」を知れない。なので「スクリーンネームにマッチした」を判断することが(今の実装では)難しい。

これらの理由により、スクリーンネームを学習の素材に含まないよう修正する。文字列としては含まなくなるが、上で挙げた「引用や返信に該当のスクリーンネームが含まれているか」は維持するので、こちらで拾われるのではないか。