### PR TITLE
本文中にあるスクリーンネームを取り除く

### DIFF
--- a/lib/feature.go
+++ b/lib/feature.go
@@ -2,6 +2,7 @@ package sabadisambiguator
 
 import (
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -141,7 +142,9 @@ func ExtractFeaturesWithOptions(t *twitter2.Tweet, opts ExtractOptions) FeatureV
 	text := t.Text
 
 	fv = append(fv, "BIAS")
-	if len(opts.ScreenNames) == 0 {
+	if len(opts.ScreenNames) > 0 {
+		text = removeScreenNames(text)
+	} else {
 		fv = append(fv, "ScreenName:"+t.User.UserName)
 		fv = append(fv, "inReplyToScreenName:"+inReplyToScreenName(t))
 		fv = append(fv, "screenNameInQuotedStatus:"+screenNameInQuotedStatus(t))
@@ -158,4 +161,11 @@ func ExtractFeaturesWithOptions(t *twitter2.Tweet, opts ExtractOptions) FeatureV
 	fv = append(fv, hashtagsInEntities(t)...)
 	fv = append(fv, wordsInUrlPaths(t)...)
 	return fv
+}
+
+// https://help.twitter.com/managing-your-account/x-username-rules
+var screenNamePattern = regexp.MustCompile("@[a-zA-Z0-9_]{4,50}[ \t]*")
+
+func removeScreenNames(s string) string {
+	return screenNamePattern.ReplaceAllLiteralString(s, "")
 }

--- a/lib/feature_test.go
+++ b/lib/feature_test.go
@@ -1,0 +1,19 @@
+package sabadisambiguator
+
+import (
+	"testing"
+)
+
+func TestRemoveScreenNames(t *testing.T) {
+	tests := map[string]string{
+		"@screen text":        "text",
+		"@screen aaa@screen2": "aaa",
+		".@screen":            ".",
+	}
+	for in, want := range tests {
+		s := removeScreenNames(in)
+		if s != want {
+			t.Errorf("removeScreenNames(%q) = %q; want %q", in, s, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #260

実装メモ

- screenNamesがない場合は、従来の挙動(使えるものは全部学習対象にする、スクリーンネームもそう)なので除外していない
- screenNamesがある場合は、固定のスクリーンネームだけに反応したい意思があるからbodyに含まれているスクリーンネームは除外する